### PR TITLE
ワークフローの権限と prompt の文言を更新

### DIFF
--- a/.github/workflows/claude-code-issue.yaml
+++ b/.github/workflows/claude-code-issue.yaml
@@ -23,6 +23,7 @@ on:
         required: true
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
   issues: write

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -23,6 +23,7 @@ on:
         required: true
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
   issues: write
@@ -62,7 +63,7 @@ jobs:
             PR NUMBER: ${{ github.event.pull_request.number }}
 
             この PR をレビューし、具体的で実行可能なフィードバックを提供してください。
-            特定の問題にはインラインコメントを使用し、一般的な観察や称賛にはトップレベルのコメントを使用してください。
+            行ごとの問題にはインラインコメントを使用し、一般的な観察や称賛にはトップレベルのコメントを使用してください。
 
             レビューの際は、以下の点に注意してください：
             - コードの品質とベストプラクティス


### PR DESCRIPTION
## 概要

ワークフローに `actions:read` 権限を追加し、prompt の文言を微調整しました。

## 変更内容

### 両ワークフロー共通
- `permissions` に `actions:read` を追加

### `.github/workflows/claude-code.yml`
- prompt の文言を「行ごとの問題には〜」に変更（より明確に）

## 関連

- #24 の follow-up