### PR TITLE
Claude が GitHub Actions の CI 結果を参照できるよう設定

### DIFF
--- a/.github/workflows/claude-code-issue.yaml
+++ b/.github/workflows/claude-code-issue.yaml
@@ -52,6 +52,9 @@ jobs:
           track_progress: true
           use_bedrock: true
 
+          additional_permissions: |
+            actions: read
+
           claude_args: |
             --model ${{ inputs.model }}
 

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -52,6 +52,9 @@ jobs:
           track_progress: true
           use_bedrock: true
 
+          additional_permissions: |
+            actions: read
+
           claude_args: |
             --model ${{ inputs.model }}
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## 概要

Claude が GitHub Actions の CI 結果を参照できるよう `additional_permissions` を追加しました。

## 変更内容

両ワークフローに以下を追加：
```yaml
additional_permissions: |
  actions: read
```

これにより、Claude が以下を実行できるようになります：
- GitHub Actions のワークフロー実行結果の参照
- ジョブログの確認
- CI の失敗原因の分析とデバッグ

## 参考

- [FAQ: Can Claude see my GitHub Actions CI results?](https://github.com/anthropics/claude-code-action/blob/main/docs/faq.md#can-claude-see-my-github-actions-ci-results)