### PR TITLE
fix(auto-release-pr): リリースPRへの重複コメント・空コメントを防止

### DIFF
--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -66,6 +66,10 @@ jobs:
   update:
     name: Update Release PR
     runs-on: ubuntu-slim
+    # 並列実行による二重コメントを防ぐ
+    concurrency:
+      group: ${{ github.repository }}-release-pr-update
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/scripts/auto-release-pr/pr-updater.mjs
+++ b/scripts/auto-release-pr/pr-updater.mjs
@@ -66,6 +66,11 @@ function getFirstNewLine(oldText, newText) {
 export async function updatePrBody(pr, newBody, commentTemplate) {
     const oldBody = pr.body || "";
 
+    if (oldBody === newBody) {
+        console.log("\nPR body is unchanged, skipping update and comment.");
+        return;
+    }
+
     console.log("\nUpdating PR body...");
 
     // PR の body を更新


### PR DESCRIPTION
## Summary

- 複数のPRがほぼ同時にmasterへマージされた際に、ワークフローが並列実行されてリリースPRへのコメントが二重投稿される問題を修正
- PR bodyに変更がない場合でも空のdiffコメントが投稿される問題を修正

## 変更内容

**`auto-release-pr.yml`**: `update` ジョブに `concurrency` を追加し、同一リポジトリからの実行を直列化

**`pr-updater.mjs`**: `oldBody === newBody` の場合に更新・コメント投稿をスキップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)