### PR TITLE
fix: pull_request_review 時に CodeBuild が merge commit を fetch できず失敗する問題を修正

### DIFF
--- a/.github/workflows/kick-codebuild.yaml
+++ b/.github/workflows/kick-codebuild.yaml
@@ -29,6 +29,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          # pull_request_review イベントではデフォルトで merge commit が checkout されるが、
+          # CodeBuild は ephemeral な merge commit の SHA を fetch できないため失敗する。
+          # pull_request_review 時は PR HEAD の SHA を明示的に指定する。
+          ref: ${{ github.event_name == 'pull_request_review' && github.event.pull_request.head.sha || '' }}
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:


### PR DESCRIPTION
## 問題

`pull_request_review` イベントでワークフローがトリガーされると、`actions/checkout` はデフォルトで `refs/pull/N/merge`（GitHub が生成する ephemeral な merge commit）を checkout する。

`aws-codebuild-run-build` はこの merge commit の SHA を CodeBuild に渡すが、CodeBuild は通常の git clone でこの ephemeral な参照を fetch できないため、以下のエラーで失敗する：

```
fatal: reference is not a tree: <merge commit SHA>
```

## 修正内容

`pull_request_review` 時は `github.event.pull_request.head.sha`（PR ブランチの実際の HEAD commit）を checkout の `ref` に明示的に指定する。

これにより CodeBuild がアクセス可能な通常のブランチ commit が使われ、問題が解消される。

他のイベント（`push`, `merge_group` など）では `ref` が空文字となりデフォルト動作を維持する。