### PR TITLE
fix: claude-code-action を v1.0.89 から v1.0.88 にダウングレード

### DIFF
--- a/.github/workflows/claude-pr-auto-review.yml
+++ b/.github/workflows/claude-pr-auto-review.yml
@@ -54,7 +54,7 @@ jobs:
           aws-region: ${{ inputs.region }}
 
       - name: Claude Automatic Code Review
-        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
+        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47 # v1.0.88
         with:
           track_progress: true
           use_bedrock: true


### PR DESCRIPTION
## 問題

v1.0.89 で導入された `restoreConfigFromBase`（PR head を信頼せず `origin/main` の設定ファイルに差し替えるセキュリティ機構）に、シンボリックリンクを含むリポジトリでクラッシュするバグがある（anthropics/claude-code-action#1187）。

`cpSync` が `dereference: false` で呼ばれるため、シンボリックリンクをそのまま再作成しようとするが、コピー先の `.claude-pr/` ディレクトリがまだ存在しない状態で `symlink()` が呼ばれ `ENOENT` で失敗する。

`.claude` がシンボリックリンクになっているリポジトリ（例: xflagstudio/m-store）でコードレビュー CI が毎回 fail する状態になっている。

## 修正内容

`claude-code-action` を v1.0.89（`6e2bd52`）から v1.0.88（`1eddb334`）にダウングレードしてピン留めする。v1.0.88 には `restoreConfigFromBase` 自体がなく、問題が発現しない。

fix PR（anthropics/claude-code-action#1186）がマージされ新バージョンがリリースされ次第、バージョンを戻す。