### PR TITLE
fix: 残りの claude-code-action を v1.0.89 から v1.0.88 にダウングレード

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -47,7 +47,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.region }}
 
-      - uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
+      - uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47 # v1.0.88
         with:
           track_progress: true
           use_bedrock: true

--- a/.github/workflows/review-dependabot.yml
+++ b/.github/workflows/review-dependabot.yml
@@ -45,7 +45,7 @@ jobs:
           aws-region: ${{ inputs.region }}
 
       - name: Claude AI Review (Comment Only)
-        uses: anthropics/claude-code-action@6e2bd52842c65e914eba5c8badd17560bd26b5de # v1.0.89
+        uses: anthropics/claude-code-action@1eddb334cfa79fdb21ecbe2180ca1a016e8e7d47 # v1.0.88
         with:
           use_bedrock: true
           track_progress: true


### PR DESCRIPTION
## 問題

#44 で `claude-pr-auto-review.yml` を修正したが、`review-dependabot.yml` と `claude-code.yml` にも同じ v1.0.89 がハードコードされており、Dependabot PR で同一の CI fail が発生している

## 修正内容

以下の 2 ファイルの `claude-code-action` を v1.0.89（`6e2bd52`）から v1.0.88（`1eddb334`）にダウングレード。

- `.github/workflows/review-dependabot.yml`
- `.github/workflows/claude-code.yml`

anthropics/claude-code-action#1186（symlink バグの fix PR）がマージされ次第、全ワークフローを最新版に戻す。