### PR TITLE
fix(cdk-diff): get-template に --template-stage Original を明示して phantom diff を解消

### DIFF
--- a/scripts/cdk-diff/cfn-template.mjs
+++ b/scripts/cdk-diff/cfn-template.mjs
@@ -24,9 +24,11 @@ export async function getCfnTemplates(stackNames) {
         console.log(`Found ${cfnStackNames.length} existing CloudFormation stacks: ${cfnStackNames.join(", ")}`);
 
         // 各 Stack の template を取得
+        // --template-stage Original を明示することで SAM Transform 含むスタックでも
+        // 展開前の未処理テンプレートを取得し、cdk synth 結果との phantom diff を防ぐ
         const cfnTemplates = {};
         for (const stackName of cfnStackNames) {
-            const command = await $`aws cloudformation get-template --stack-name ${stackName}`;
+            const command = await $`aws cloudformation get-template --stack-name ${stackName} --template-stage Original`;
             cfnTemplates[stackName] = JSON.parse(command.stdout).TemplateBody;
             console.log(`Loaded CloudFormation template for stack: ${stackName}`);
         }


### PR DESCRIPTION
## 概要

`scripts/cdk-diff/cfn-template.mjs` の `aws cloudformation get-template` に `--template-stage Original` を追加する。

## 背景・原因

SAM Transform を含むスタックで CI の `cdk diff` に毎回 phantom diff が出続ける問題が報告された:

```
[+] Transform Transform: ["AWS::Serverless-2016-10-31"]
[~] AWS::Serverless::Application AthenaMySQLConnector replace
```

調査の結果、原因は `--template-stage` を未指定で `get-template` を呼んでいること。

AWS CLI ドキュメント上のデフォルトは `Original` だが、SAM Transform を含むスタックでは実際には **Processed テンプレート（Transform 展開済み）が返ってくる**。

Processed では:
- `Transform` フィールドが消える
- `AWS::Serverless::Application` が `AWS::CloudFormation::Stack`（ネステッドスタック）に置き換わる

これと `cdk synth` の未処理テンプレートを `@aws-cdk/cloudformation-diff#fullDiff` で比較するため phantom diff が発生する。

## 検証結果

SAM Transform を含むスタックで実測:

| クエリ | `Transform` | `AWS::Serverless::Application` の Type |
|---|---|---|
| `--template-stage Original` 明示 | 文字列で残る | `AWS::Serverless::Application` のまま |
| 未指定（修正前と同条件） | `null` | `AWS::CloudFormation::Stack` に置き換わる |

`cdk synth` 結果と `--template-stage Original` で取得したテンプレートを `jq -S` で正規化して `diff` → **完全一致**。

## 変更内容

```diff
- const command = await $`aws cloudformation get-template --stack-name ${stackName}`;
+ const command = await $`aws cloudformation get-template --stack-name ${stackName} --template-stage Original`;
```

## 影響範囲

- SAM/Include 等の Transform を使っていないスタック: Original / Processed は同一内容のため影響なし
- SAM Transform を使っているスタック: phantom diff が解消される