### PR TITLE
feat: デフォルトモデルを claude-opus-4-7 に更新

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-sonnet-4-5-20250929-v1:0'
+        default: 'global.anthropic.claude-opus-4-7'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/claude-pr-auto-review.yml
+++ b/.github/workflows/claude-pr-auto-review.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-sonnet-4-6'
+        default: 'global.anthropic.claude-opus-4-7'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/review-dependabot.yml
+++ b/.github/workflows/review-dependabot.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-sonnet-4-6'
+        default: 'global.anthropic.claude-opus-4-7'
       region:
         description: 'AWS region to use'
         required: false


### PR DESCRIPTION
## 概要

各ワークフローの `model` input のデフォルト値を `global.anthropic.claude-opus-4-7` に更新する。

## 変更内容

| ワークフロー | 変更前 | 変更後 |
|---|---|---|
| `claude-code.yml` | `global.anthropic.claude-sonnet-4-5-20250929-v1:0` | `global.anthropic.claude-opus-4-7` |
| `claude-pr-auto-review.yml` | `global.anthropic.claude-sonnet-4-6` | `global.anthropic.claude-opus-4-7` |
| `review-dependabot.yml` | `global.anthropic.claude-sonnet-4-6` | `global.anthropic.claude-opus-4-7` |

## 影響範囲

- 各ワークフローを呼び出す際に `model` input を明示していない場合、`claude-opus-4-7` が使用される
- `model` input を明示している場合は従来通りそちらが優先される