### PR TITLE
fix: デフォルトモデルを claude-opus-4-6 に変更

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-7'
+        default: 'global.anthropic.claude-opus-4-6'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/claude-pr-auto-review.yml
+++ b/.github/workflows/claude-pr-auto-review.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-7'
+        default: 'global.anthropic.claude-opus-4-6'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/review-dependabot.yml
+++ b/.github/workflows/review-dependabot.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-7'
+        default: 'global.anthropic.claude-opus-4-6'
       region:
         description: 'AWS region to use'
         required: false

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -33,7 +33,7 @@ permissions:
 | パラメータ | Required | Default | |
 |-|-|-|-|
 | `runs-on` | | `ubuntu-latest` | ジョブを実行するマシンの種類 |
-| `model` | | `apac.anthropic.claude-sonnet-4-20250514-v1:0` | 使用するClaudeモデル |
+| `model` | | `global.anthropic.claude-opus-4-6` | 使用するClaudeモデル |
 | `region` | | `ap-northeast-1` | 使用するAWSリージョン |
 
 ## Secrets
@@ -84,7 +84,7 @@ jobs:
     uses: mixi-m/github-actions/.github/workflows/claude-code.yml@master
     with:
       runs-on: 'ubuntu-latest'  # オプション、デフォルト: ubuntu-latest
-      model: 'apac.anthropic.claude-sonnet-4-20250514-v1:0'  # オプション
+      model: 'global.anthropic.claude-opus-4-6'  # オプション
       region: 'ap-northeast-1'  # オプション、デフォルト: ap-northeast-1
     secrets:
       AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
## 概要

各ワークフローの `model` input のデフォルト値を `global.anthropic.claude-opus-4-6` に変更する。

## 背景

PR #51 で `claude-opus-4-7` をデフォルトに設定したが、現行の `claude-code-action@v1.0.88`（Bedrock 経路）と非互換のためエラーが発生している。

```
API Error: 400 "thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

原因は `claude-opus-4-7` で thinking API の仕様が破壊的変更され、SDK 側がまだ追従できていないため。Bedrock 経路では派生バグ（`invalid beta flag`）も未解決（`anthropics/claude-code-action#1225` / `anthropics/claude-code#49238`）。

`claude-opus-4-6` は旧 thinking API 形式を受け付けるため、現行 Action でそのまま動作する。

## 変更内容

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `claude-code.yml` | `global.anthropic.claude-opus-4-7` | `global.anthropic.claude-opus-4-6` |
| `claude-pr-auto-review.yml` | `global.anthropic.claude-opus-4-7` | `global.anthropic.claude-opus-4-6` |
| `review-dependabot.yml` | `global.anthropic.claude-opus-4-7` | `global.anthropic.claude-opus-4-6` |
| `claude-code/README.md` | `apac.anthropic.claude-sonnet-4-20250514-v1:0` | `global.anthropic.claude-opus-4-6` |

## 影響範囲

- 各ワークフローを呼び出す際に `model` input を明示していない場合、`claude-opus-4-6` が使用される
- `model` input を明示している場合は従来通りそちらが優先される

## 後続対応

`anthropics/claude-code-action` 側で Bedrock + Opus 4.7 の不具合が修正されたタイミングで、改めて 4.7 への移行 PR を出す。