### PR TITLE
fix: モデル ID を claude-opus-4-6-v1 に修正

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-6'
+        default: 'global.anthropic.claude-opus-4-6-v1'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/claude-pr-auto-review.yml
+++ b/.github/workflows/claude-pr-auto-review.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-6'
+        default: 'global.anthropic.claude-opus-4-6-v1'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/review-dependabot.yml
+++ b/.github/workflows/review-dependabot.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-6'
+        default: 'global.anthropic.claude-opus-4-6-v1'
       region:
         description: 'AWS region to use'
         required: false

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -33,7 +33,7 @@ permissions:
 | パラメータ | Required | Default | |
 |-|-|-|-|
 | `runs-on` | | `ubuntu-latest` | ジョブを実行するマシンの種類 |
-| `model` | | `global.anthropic.claude-opus-4-6` | 使用するClaudeモデル |
+| `model` | | `global.anthropic.claude-opus-4-6-v1` | 使用するClaudeモデル |
 | `region` | | `ap-northeast-1` | 使用するAWSリージョン |
 
 ## Secrets
@@ -84,7 +84,7 @@ jobs:
     uses: mixi-m/github-actions/.github/workflows/claude-code.yml@master
     with:
       runs-on: 'ubuntu-latest'  # オプション、デフォルト: ubuntu-latest
-      model: 'global.anthropic.claude-opus-4-6'  # オプション
+      model: 'global.anthropic.claude-opus-4-6-v1'  # オプション
       region: 'ap-northeast-1'  # オプション、デフォルト: ap-northeast-1
     secrets:
       AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
## 概要

`global.anthropic.claude-opus-4-6` は無効なモデル ID のため、正しい ID `global.anthropic.claude-opus-4-6-v1` に修正する。

## 変更内容

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `claude-code.yml` | `global.anthropic.claude-opus-4-6` | `global.anthropic.claude-opus-4-6-v1` |
| `claude-pr-auto-review.yml` | `global.anthropic.claude-opus-4-6` | `global.anthropic.claude-opus-4-6-v1` |
| `review-dependabot.yml` | `global.anthropic.claude-opus-4-6` | `global.anthropic.claude-opus-4-6-v1` |
| `claude-code/README.md` | `global.anthropic.claude-opus-4-6` | `global.anthropic.claude-opus-4-6-v1` |

## 影響範囲

- 各ワークフローを呼び出す際に `model` input を明示していない場合、`claude-opus-4-6-v1` が使用される
- `model` input を明示している場合は従来通りそちらが優先される