### PR TITLE
fix(cdk-diff): CFn API による非 ASCII 文字の phantom diff を抑制する

### DIFF
--- a/scripts/cdk-diff/comment-formatter.mjs
+++ b/scripts/cdk-diff/comment-formatter.mjs
@@ -40,6 +40,7 @@ export function formatComment({
     cfnStacks,
     editedStackCount,
     stackDriftDetected,
+    filteredChangesCounts = {},
 }) {
     const messageHeading = getCommentHeading(environmentAlias);
     let comment = `${messageHeading}\n\n\n`;
@@ -63,6 +64,7 @@ export function formatComment({
             cfnStackResourcesSummaries,
             cfnStacks,
             awsRegion,
+            filteredChangesCount: filteredChangesCounts[stackName] ?? 0,
         });
     }
 
@@ -126,6 +128,7 @@ function formatStackDetail({
     cfnStackResourcesSummaries,
     cfnStacks,
     awsRegion,
+    filteredChangesCount = 0,
 }) {
     let comment = "";
 
@@ -170,6 +173,9 @@ function formatStackDetail({
     comment += "<summary>cdk diff</summary>\n\n";
     comment += "```\n";
     comment += cleanDiff;
+    if (filteredChangesCount > 0) {
+        comment += `\nOmitted ${filteredChangesCount} change(s) because they are likely mangled non-ASCII characters. Use --strict to print them.`;
+    }
     comment += "\n```\n\n";
     comment += "</details>\n\n";
 

--- a/scripts/cdk-diff/diff-calculator.mjs
+++ b/scripts/cdk-diff/diff-calculator.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env zx
 
 import { PassThrough } from "node:stream";
-import { formatDifferences, fullDiff } from "@aws-cdk/cloudformation-diff";
+import { formatDifferences, fullDiff, mangleLikeCloudFormation } from "@aws-cdk/cloudformation-diff";
 import { chalk } from "zx";
 
 /**
@@ -15,26 +15,44 @@ export function calculateDiff(stackNames, cfnTemplates, stackTemplates) {
     console.log("##[group]Calculate Template Diff");
 
     const templateDiff = {};
+    const filteredChangesCounts = {};
     let editedStackCount = 0;
 
     for (const stackName of stackNames) {
         const currentTemplate = cfnTemplates[stackName] ?? {};
         const newTemplate = stackTemplates[stackName];
 
-        templateDiff[stackName] = fullDiff(currentTemplate, newTemplate);
+        const rawDiff = fullDiff(currentTemplate, newTemplate);
 
-        if (templateDiff[stackName].differenceCount) {
+        // CFn の GetStackTemplate API は U+0080 以上を '?' に潰して返すため、
+        // 同じ変換を新テンプレートに施した版で再 diff し、phantom diff を除去する。
+        // (@aws-cdk/toolkit-lib の formatStackDiffHelper と同等の処理)
+        let activeDiff = rawDiff;
+        let filteredCount = 0;
+        if (rawDiff.differenceCount && newTemplate) {
+            const mangledNewTemplate = JSON.parse(mangleLikeCloudFormation(JSON.stringify(newTemplate)));
+            const mangledDiff = fullDiff(currentTemplate, mangledNewTemplate);
+            filteredCount = Math.max(0, rawDiff.differenceCount - mangledDiff.differenceCount);
+            if (filteredCount > 0) {
+                activeDiff = mangledDiff;
+            }
+        }
+
+        templateDiff[stackName] = activeDiff;
+        filteredChangesCounts[stackName] = filteredCount;
+
+        if (activeDiff.differenceCount) {
             editedStackCount += 1;
-            console.log(`Stack ${stackName} has ${templateDiff[stackName].differenceCount} difference(s)`);
+            console.log(`Stack ${stackName} has ${activeDiff.differenceCount} difference(s)${filteredCount > 0 ? ` (omitted ${filteredCount} mangled non-ASCII change(s))` : ""}`);
         } else {
-            console.log(`Stack ${stackName} has no differences`);
+            console.log(`Stack ${stackName} has no differences${filteredCount > 0 ? ` (omitted ${filteredCount} mangled non-ASCII change(s))` : ""}`);
         }
     }
 
     console.log(`Total stacks with changes: ${editedStackCount}/${stackNames.length}`);
     console.log("##[endgroup]");
 
-    return { templateDiff, editedStackCount };
+    return { templateDiff, editedStackCount, filteredChangesCounts };
 }
 
 /**

--- a/scripts/cdk-diff/main.mjs
+++ b/scripts/cdk-diff/main.mjs
@@ -33,7 +33,7 @@ async function main() {
         const { cfnStackNames, cfnTemplates, cfnStacks } = await getCfnTemplates(stackNames);
 
         // 3. Stack の差分を計算
-        const { templateDiff, editedStackCount } = calculateDiff(stackNames, cfnTemplates, stackTemplates);
+        const { templateDiff, editedStackCount, filteredChangesCounts } = calculateDiff(stackNames, cfnTemplates, stackTemplates);
 
         // 4. Stack の Drift を検知
         const stackDriftDetected = await detectStackDrift(stackNames, cfnStackNames, config.driftDetectionTimeout);
@@ -54,6 +54,7 @@ async function main() {
             cfnStacks,
             editedStackCount,
             stackDriftDetected,
+            filteredChangesCounts,
         });
 
         // 7. PR にコメントを投稿


### PR DESCRIPTION
## 概要

`cdk-diff-on-pr` で日本語などの非 ASCII 文字を含むリソースプロパティ（ALB 固定レスポンスの `MessageBody` など）が、実際には変更されていないにもかかわらず `??????` として差分検出される問題を修正する。

### 根本原因

CloudFormation の `GetStackTemplate` API は仕様として U+0080 以上のすべてのコードポイントを `?` に flatten して返す。一方 `cdk synth` のローカル出力は UTF-8 のままなので、両者を直接 diff すると phantom diff が発生する。

aws-cdk PR [#25912](https://github.com/aws/aws-cdk/pull/25912) でこの問題に対処するフィルタが CLI に追加されているが、そのロジックは `@aws-cdk/cloudformation-diff` ライブラリではなく上位の toolkit-lib 層に置かれている。本リポジトリは `@aws-cdk/cloudformation-diff` の `fullDiff()` を直接呼んでいるため、このフィルタが適用されていなかった。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `scripts/cdk-diff/diff-calculator.mjs` | `mangleLikeCloudFormation` を import し、`fullDiff` の後に mangle 版新テンプレートで再 diff してフィルタするロジックを追加。返り値に `filteredChangesCounts` を追加 |
| `scripts/cdk-diff/main.mjs` | `filteredChangesCounts` を `calculateDiff` の戻り値から受け取り `formatComment` に渡す |
| `scripts/cdk-diff/comment-formatter.mjs` | cdk diff セクション末尾にフィルタされた差分数を `Omitted N change(s)...` として表示 |

### 対処方針

`@aws-cdk/toolkit-lib` の `formatStackDiffHelper` と同等のロジックを移植：

1. `fullDiff(oldTemplate, newTemplate)` で通常 diff を計算
2. `mangleLikeCloudFormation(JSON.stringify(newTemplate))` で新テンプレートを CFn API と同じ規則で変換し、再度 `fullDiff` を計算
3. 差分数が減った場合は mangle 版を採用し、除外した差分数を PR コメントに明示

## 影響範囲

- 非 ASCII 文字を含むリソースプロパティで phantom diff が表示されなくなる
- フィルタした差分数がある場合は `Omitted N change(s) because they are likely mangled non-ASCII characters.` としてコメントに表示される（実際の変更が隠れていないかユーザーが判断できるよう明示）
- 実際にリソースが変更されている場合の差分検出には影響しない

## 参照

- aws-cdk 側の修正: https://github.com/aws/aws-cdk/pull/25912