### PR TITLE
fix: kick-codebuild に最小権限の permissions ブロックを追加

### DIFF
--- a/.github/workflows/kick-codebuild.yaml
+++ b/.github/workflows/kick-codebuild.yaml
@@ -21,6 +21,10 @@ on:
         type: string
         default: ubuntu-latest
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   execute:
     runs-on: ${{ inputs.platform }}


### PR DESCRIPTION
## 概要

`kick-codebuild.yaml` に `permissions` ブロックが定義されておらず、デフォルト権限が付与されていた。
他のワークフローと同様に、必要最小限の権限を明示する。

## 変更内容

| ファイル | 変更内容 |
|---|---|
| `kick-codebuild.yaml` | `permissions` ブロックを追加（`id-token: write`, `contents: read`） |

追加した権限はそれぞれ以下の用途で必要。

- `id-token: write` — OIDC による AWS 認証（`role-to-assume`）
- `contents: read` — リポジトリの checkout

## 影響範囲

- このワークフローを呼び出しているワークフローの実行権限に変更はない（元々必要な権限のみ追加）
