### PR TITLE
Claude workflow のデフォルトモデルを更新

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-6-v1'
+        default: 'global.anthropic.claude-opus-4-7'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/claude-pr-auto-review.yml
+++ b/.github/workflows/claude-pr-auto-review.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-6-v1'
+        default: 'global.anthropic.claude-opus-4-7'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/review-dependabot.yml
+++ b/.github/workflows/review-dependabot.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-6-v1'
+        default: 'global.anthropic.claude-opus-4-7'
       region:
         description: 'AWS region to use'
         required: false


### PR DESCRIPTION
## 概要

再利用 workflow の model input のデフォルト値を global.anthropic.claude-opus-4-7 に更新します。

## 影響範囲

- .github/workflows/claude-code.yml
- .github/workflows/claude-pr-auto-review.yml
- .github/workflows/review-dependabot.yml

明示的に model input を指定している呼び出し元には影響ありません。未指定の場合のみ新しいモデルが使われます。

## 確認事項

- [x] コーディングガイドラインに従っている
- [x] この差分がセキュリティに悪影響を与えていない

## 動作確認

- git diff --check -- .github/workflows/claude-code.yml .github/workflows/claude-pr-auto-review.yml .github/workflows/review-dependabot.yml
- rg -n "global\.anthropic\.claude-opus-4-(6-v1|7)|model:" .github/workflows