### PR TITLE
サプライチェーン攻撃対策とActions権限最小化を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/review-dependabot.yml
+++ b/.github/workflows/review-dependabot.yml
@@ -22,6 +22,13 @@ on:
       AWS_ROLE_TO_ASSUME:
         required: true
 
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+  issues: write
+  pull-requests: write
+
 jobs:
   review:
     name: AI review comment (dependabot)


### PR DESCRIPTION
## 概要

Dependabot の GitHub Actions 更新PRに `cooldown.default-days: 7` を追加し、リリース直後の通常更新を遅らせます。あわせて reusable workflow の `GITHUB_TOKEN` 権限を用途に合わせて明示します。

## 影響範囲

- GitHub Actions の Dependabot version updates が7日待機されます。
- security updates は GitHub Docs 上 cooldown の対象外です。
- Dependabot PR review workflow は、コメント投稿と AWS OIDC 認証に必要な `actions: read` / `contents: read` / `id-token: write` / `issues: write` / `pull-requests: write` のみを使用します。
- reusable workflow の処理内容への影響はありません。

## 確認事項

- [x] コーディングガイドラインに従っている
- [x] この差分がセキュリティに悪影響を与えていない

## 動作確認

- YAML構文チェック
- 対策設定検出スクリプト
- permissions設定検出スクリプト
- `git diff --check`
- GitHub Actions run確認（`workflow_call` のため最新commitでは checks 未報告）