### PR TITLE
feat(review-dependabot): 判定マーカー出力と Check Run publish を opt-in で追加

### DIFF
--- a/.github/workflows/review-dependabot.yml
+++ b/.github/workflows/review-dependabot.yml
@@ -18,6 +18,26 @@ on:
         required: false
         type: string
         default: 'ap-northeast-1'
+      emit-verdict:
+        description: >-
+          レビューコメントに自動マージ判定用のマーカーを埋め込むか。
+          true の場合、判定を機械可読にするため track_progress を無効化する。
+        required: false
+        type: boolean
+        default: false
+      publish-check-run:
+        description: >-
+          レビュー判定を Check Run として publish するか。
+          true の場合は emit-verdict を自動的に有効化する。
+          利用側ジョブで checks: write の付与が必要。
+        required: false
+        type: boolean
+        default: false
+      check-name:
+        description: 'publish-check-run が true のときに作成する Check Run 名'
+        required: false
+        type: string
+        default: 'dependabot-code-review'
     secrets:
       AWS_ROLE_TO_ASSUME:
         required: true
@@ -28,6 +48,8 @@ permissions:
   id-token: write
   issues: write
   pull-requests: write
+  # publish-check-run 利用時にのみ実際に使用される（呼び出し側の付与権限で上限が決まる）
+  checks: write
 
 jobs:
   review:
@@ -40,6 +62,7 @@ jobs:
       issues: write
       actions: read
       id-token: write
+      checks: write
     timeout-minutes: 30
 
     steps:
@@ -55,7 +78,9 @@ jobs:
         uses: anthropics/claude-code-action@bbfaf8e1ffe3e688f7ab65ceee78de241e24a238 # v1.0.132
         with:
           use_bedrock: true
-          track_progress: true
+          # 判定マーカーを機械解析する場合は、専用コメントに確実に残すため
+          # track_progress を無効化する（既定では従来通り有効）。
+          track_progress: ${{ !(inputs.emit-verdict || inputs.publish-check-run) }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_bots: "*"
           prompt: |
@@ -96,9 +121,43 @@ jobs:
             ## 推奨アクション
             <!-- レビュアーへの推奨事項 -->
             ```
+            ${{ (inputs.emit-verdict || inputs.publish-check-run) && 'なお自動マージ判定のため、このレビューコメントの先頭に必ず次の HTML コメント行を含めてください（画面には表示されません）。1行目: <!-- dependabot-code-review -->。続けて、破壊的変更がなく実使用箇所への悪影響もない場合は <!-- dependabot-code-verdict:approved -->、いずれかに該当する/確認できない場合は <!-- dependabot-code-verdict:changes-requested --> を付与してください。' || '' }}
 
             このPRは承認しないでください。コメントのみ残してください。
           claude_args: |
             --model ${{ inputs.model }}
             --allowedTools "Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
             --max-turns 20
+
+      # publish-check-run が true のときのみ、レビュー判定を Check Run として
+      # publish する。判定はコメントに埋め込まれた検証マーカーから導出する。
+      # 承認可マーカーがあれば success、それ以外（マーカー無しを含む）は neutral。
+      - name: Publish review verdict check run
+        if: ${{ inputs.publish-check-run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CHECK_NAME: ${{ inputs.check-name }}
+        run: |
+          set -euo pipefail
+
+          CONCLUSION=neutral
+          COMMENT_ID=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body // "" | contains("<!-- dependabot-code-review -->"))) | .id' \
+            | tail -n 1)
+          if [ -n "$COMMENT_ID" ]; then
+            BODY=$(gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" --jq '.body // ""')
+            case "$BODY" in *'<!-- dependabot-code-verdict:approved -->'*) CONCLUSION=success ;; esac
+          fi
+
+          echo "${CHECK_NAME} conclusion: ${CONCLUSION}"
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/check-runs" \
+            -f name="${CHECK_NAME}" \
+            -f head_sha="${HEAD_SHA}" \
+            -f status='completed' \
+            -f conclusion="${CONCLUSION}" \
+            -f 'output[title]=Dependabot code review' \
+            -f "output[summary]=Dependabot code review 判定: ${CONCLUSION}" \
+            > /dev/null


### PR DESCRIPTION
## 概要

`review-dependabot.yml`（reusable workflow）に、dependabot 自動マージのゲートに使えるよう **レビュー判定を機械可読化する opt-in オプション**を追加します。

いずれの入力も **デフォルト `false`** で、既存利用者の挙動は**完全に不変**です。

## 追加した入力

| input | 既定 | 説明 |
|---|---|---|
| `emit-verdict` | `false` | レビューコメントに判定マーカー（`<!-- dependabot-code-review -->` / `<!-- dependabot-code-verdict:approved\|changes-requested -->`）を埋め込む。有効時は判定を専用コメントに確実に残すため `track_progress` を無効化 |
| `publish-check-run` | `false` | レビュー判定を head SHA の **Check Run** として publish（承認可=`success` / それ以外=`neutral`）。`emit-verdict` を内包 |
| `check-name` | `dependabot-code-review` | publish する Check Run 名 |

## 利用側の例（auto-merge ゲートと組み合わせる場合）

```yaml
permissions:
  contents: read
  pull-requests: write
  issues: write
  actions: read
  id-token: write
  checks: write   # publish-check-run 利用時に必要
jobs:
  review-dependabot:
    uses: mixi-m/github-actions/.github/workflows/review-dependabot.yml@master
    with:
      publish-check-run: true
      check-name: dependabot-code-review
    secrets:
      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
```

別ワークフローがこの Check Run の結論を参照して自動マージを判断する、といった利用を想定しています。

## 後方互換性・影響範囲

- 既存呼び出し（入力なし）は **従来通りコメントのみ**・`track_progress: true` のまま。出力・権限の実挙動に変化なし。
- `permissions` に `checks: write` を追加していますが、reusable workflow の実効権限は**呼び出し側ジョブの付与権限が上限**になります。`checks: write` を付与していない既存利用者では `checks` 権限は付与されず、かつ Check Run publish ステップも `if: inputs.publish-check-run`（既定 false）でスキップされるため影響しません。

## 検証

- `actionlint` パス（exit 0）
- YAML ロード OK

## 補足（任意・別途検討）

現状この reusable は全利用者が `@master` 直参照です。今回の変更は後方互換ですが、今後の安全な配布のため **バージョンタグ運用**（例: `v1` floating tag）の導入を別途ご検討いただくのが望ましいです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
