### PR TITLE
dependabot auto-merge 共有ワークフローの追加

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,9 @@ name: Dependabot Auto-Merge
 # 判定フロー:
 #   1. head SHA に紐づく open dependabot PR を解決する
 #   2. exclude-major: true の場合、semver-major ラベルがある PR をスキップする
-#   3. 条件を満たす PR を承認して auto-merge を有効化する
+#   3. vrt-workflow-filename が指定されている場合、そのワークフローが起動された
+#      PR では vrt-check-name の Check Run も success である必要がある
+#   4. 条件を満たす PR を承認して auto-merge を有効化する
 #
 # 実マージの安全性は呼び出し元リポジトリの Ruleset（必須チェック・マージキュー等）
 # が担保する。
@@ -28,6 +30,19 @@ on:
         required: false
         type: boolean
         default: false
+      vrt-workflow-filename:
+        description: >-
+          VRT ワークフローのファイル名（例: vrt-monst.yml）。
+          指定した場合、そのワークフローが起動された PR では vrt-check-name の
+          Check Run も success である必要がある。未指定の場合は VRT チェックを行わない。
+        required: false
+        type: string
+        default: ''
+      vrt-check-name:
+        description: 'VRT の Check Run 名（vrt-workflow-filename 指定時に使用）'
+        required: false
+        type: string
+        default: 'vrt-ai-review'
       runs-on:
         description: 'The type of machine to run the job on'
         required: false
@@ -88,9 +103,31 @@ jobs:
             exit 0
           fi
 
+          # VRT ワークフローが指定されている場合、起動された PR では VRT チェックも必須
+          APPROVE_BODY="依存コードレビューが問題なしのため自動承認します。"
+          VRT_WORKFLOW="${{ inputs.vrt-workflow-filename }}"
+          if [ -n "$VRT_WORKFLOW" ]; then
+            VRT_RUNS=$(gh api \
+              "repos/${GH_REPO}/actions/workflows/${VRT_WORKFLOW}/runs?head_sha=${HEAD_SHA}&per_page=1" \
+              --jq '.total_count')
+            if [ "${VRT_RUNS:-0}" -gt 0 ]; then
+              VRT_CONCLUSION=$(gh api \
+                "repos/${GH_REPO}/commits/${HEAD_SHA}/check-runs?check_name=${{ inputs.vrt-check-name }}&per_page=100" \
+                --jq '[.check_runs[] | select(.app.slug == "github-actions")] | sort_by(.completed_at // .started_at) | last | .conclusion // ""')
+              echo "PR #${PR_NUMBER}: VRT 対象 (runs=${VRT_RUNS}) / ${{ inputs.vrt-check-name }}=${VRT_CONCLUSION:-未完了}"
+              if [ "$VRT_CONCLUSION" != "success" ]; then
+                echo "VRT 対象 PR で ${{ inputs.vrt-check-name }} が success ではないためスキップします。"
+                exit 0
+              fi
+              APPROVE_BODY="依存コードレビューおよび VRT AI レビューが問題なしのため自動承認します。"
+            else
+              echo "PR #${PR_NUMBER}: VRT 非対象（${VRT_WORKFLOW} 未起動）。依存コードレビューのみで判定します。"
+            fi
+          fi
+
           echo "PR #${PR_NUMBER}: 検証チェックが揃いました。承認して auto-merge を有効化します。"
           gh pr review "$PR_NUMBER" --approve \
-            --body "依存コードレビューが問題なしのため自動承認します。" \
+            --body "$APPROVE_BODY" \
             || echo "承認をスキップしました（既に承認済み、または Actions による承認が無効化されている可能性があります）。"
 
           # マージ方式はリポジトリのキュー設定が優先されるため、--merge 指定が

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,104 @@
+name: Dependabot Auto-Merge
+
+# dependabot PR の自動マージゲート。
+#
+# 呼び出し元は check_run イベントをトリガーにして、対象の Check Run のみに
+# 絞り込んだうえでこのワークフローを呼び出す。
+#
+# 判定フロー:
+#   1. head SHA に紐づく open dependabot PR を解決する
+#   2. exclude-major: true の場合、semver-major ラベルがある PR をスキップする
+#   3. 条件を満たす PR を承認して auto-merge を有効化する
+#
+# 実マージの安全性は呼び出し元リポジトリの Ruleset（必須チェック・マージキュー等）
+# が担保する。
+#
+# 前提となるリポジトリ設定（呼び出し元で手動有効化が必要）:
+#   - Settings > General > "Allow auto-merge"
+#   - Settings > Actions > General > "Allow GitHub Actions to create and approve
+#     pull requests"
+
+on:
+  workflow_call:
+    inputs:
+      exclude-major:
+        description: >-
+          semver-major ラベルが付いた PR を自動マージ対象外にするか。
+          true の場合、major バージョンアップは人間レビュー必須となる。
+        required: false
+        type: boolean
+        default: false
+      runs-on:
+        description: 'The type of machine to run the job on'
+        required: false
+        type: string
+        default: 'ubuntu-latest'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge dependabot PR
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 10
+    concurrency:
+      group: dependabot-auto-merge-${{ github.event.check_run.head_sha }}
+      cancel-in-progress: false
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      HEAD_SHA: ${{ github.event.check_run.head_sha }}
+    steps:
+      - name: Resolve PR and evaluate gates
+        run: |
+          set -euo pipefail
+
+          # head SHA に紐づく open PR を解決する
+          PR_NUMBER=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/pulls" \
+            --jq 'map(select(.state == "open"))[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "head SHA ${HEAD_SHA} に対応する open PR が見つかりません。スキップします。"
+            exit 0
+          fi
+
+          # dependabot / open / 非 draft であることを確認する
+          INFO=$(gh pr view "$PR_NUMBER" \
+            --json author,state,isDraft,labels \
+            --jq '[.author.login, .state, (.isDraft | tostring), ([.labels[].name] | join(","))] | @tsv')
+          IFS=$'\t' read -r AUTHOR STATE DRAFT LABELS <<< "$INFO"
+
+          case "$AUTHOR" in
+            *dependabot*) ;;
+            *) echo "dependabot PR ではありません (author=${AUTHOR})。スキップします。"; exit 0 ;;
+          esac
+          if [ "$STATE" != "OPEN" ]; then
+            echo "PR が open ではありません (state=${STATE})。スキップします。"
+            exit 0
+          fi
+          if [ "$DRAFT" != "false" ]; then
+            echo "PR が draft です。スキップします。"
+            exit 0
+          fi
+
+          # major バージョンアップは exclude-major: true のとき人間レビュー必須
+          if [ "${{ inputs.exclude-major }}" = "true" ] && echo "$LABELS" | grep -q "semver-major"; then
+            echo "major バージョンアップのため自動マージをスキップします (labels=${LABELS})。"
+            exit 0
+          fi
+
+          echo "PR #${PR_NUMBER}: 検証チェックが揃いました。承認して auto-merge を有効化します。"
+          gh pr review "$PR_NUMBER" --approve \
+            --body "依存コードレビューが問題なしのため自動承認します。" \
+            || echo "承認をスキップしました（既に承認済み、または Actions による承認が無効化されている可能性があります）。"
+
+          # マージ方式はリポジトリのキュー設定が優先されるため、--merge 指定が
+          # 拒否される場合は方式なしで再試行する。
+          if gh pr merge "$PR_NUMBER" --auto --merge; then
+            echo "auto-merge を有効化しました。"
+          elif gh pr merge "$PR_NUMBER" --auto; then
+            echo "auto-merge を有効化しました（マージ方式はキュー設定に委譲）。"
+          else
+            echo "::warning::auto-merge を有効化できませんでした。リポジトリ設定の 'Allow auto-merge' が有効か確認してください。"
+          fi


### PR DESCRIPTION
## 概要

dependabot PR の自動マージ判定ロジックを共有ワークフローとして追加します。

各リポジトリが `check_run` イベントをトリガーにしてこのワークフローを呼び出すことで、重複した自動マージロジックを一元管理できます。

## 追加ファイル

`.github/workflows/dependabot-auto-merge.yml`

## パラメータ

| input | 型 | デフォルト | 説明 |
|---|---|---|---|
| `exclude-major` | bool | `false` | `semver-major` ラベル付き PR を自動マージ除外 |
| `vrt-workflow-filename` | string | `''` | VRT ワークフローのファイル名。指定時は VRT が起動された PR で `vrt-check-name` も `success` を要求 |
| `vrt-check-name` | string | `vrt-ai-review` | VRT の Check Run 名 |
| `runs-on` | string | `ubuntu-latest` | ランナー指定 |

## 確認事項

- [x] コーディングガイドラインに従っている
- [x] この差分がセキュリティに悪影響を与えていない