### PR TITLE
VRT AI Review 共有ワークフローの追加

### DIFF
--- a/.github/actions/publish-check-run/action.yml
+++ b/.github/actions/publish-check-run/action.yml
@@ -1,0 +1,75 @@
+name: Publish verdict check run
+description: >-
+  レビュー判定を head SHA の Check Run として publish する。
+  dependabot-auto-merge.yml が照会する機械可読チャネル。
+
+inputs:
+  github-token:
+    description: gh CLI 用トークン
+    required: true
+  check-name:
+    description: 作成する Check Run 名（dependabot-auto-merge.yml が参照する名前）
+    required: true
+  title:
+    description: Check Run のタイトル
+    required: true
+  head-sha:
+    description: Check Run を紐づける commit SHA
+    required: true
+  pr-number:
+    description: 判定コメントを探す対象 PR 番号（conclusion-override 指定時は未使用）
+    required: false
+    default: ""
+  marker:
+    description: 判定コメントを特定する HTML マーカー（conclusion-override 指定時は未使用）
+    required: false
+    default: ""
+  ok-marker:
+    description: success と判定する検証マーカー（conclusion-override 指定時は未使用）
+    required: false
+    default: ""
+  conclusion-override:
+    description: 指定時はコメント探索を行わずこの conclusion をそのまま使う
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        CHECK_NAME: ${{ inputs.check-name }}
+        TITLE: ${{ inputs.title }}
+        HEAD_SHA: ${{ inputs.head-sha }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+        MARKER: ${{ inputs.marker }}
+        OK_MARKER: ${{ inputs.ok-marker }}
+        CONCLUSION_OVERRIDE: ${{ inputs.conclusion-override }}
+      run: |
+        set -euo pipefail
+
+        if [ -n "$CONCLUSION_OVERRIDE" ]; then
+          CONCLUSION="$CONCLUSION_OVERRIDE"
+        else
+          # github-actions[bot] が投稿した判定コメントの検証マーカーで判定する。
+          # マーカーが見つからなければ neutral（＝非 success）にフォールバックする。
+          CONCLUSION=neutral
+          BODY=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq ".[] | select(.user.login == \"github-actions[bot]\" and (.body // \"\" | contains(\"${MARKER}\"))) | .body // \"\"" \
+            | tail -n 1)
+          if [[ "${BODY}" == *"${OK_MARKER}"* ]]; then
+            CONCLUSION=success
+          fi
+        fi
+
+        echo "${CHECK_NAME} conclusion: ${CONCLUSION}"
+        gh api -X POST "repos/${GITHUB_REPOSITORY}/check-runs" \
+          -f name="${CHECK_NAME}" \
+          -f head_sha="${HEAD_SHA}" \
+          -f status='completed' \
+          -f conclusion="${CONCLUSION}" \
+          -f "output[title]=${TITLE}" \
+          -f "output[summary]=${TITLE} 判定: ${CONCLUSION}（dependabot 自動マージ用の検証チェック）" \
+          > /dev/null

--- a/.github/workflows/vrt-ai-review.yml
+++ b/.github/workflows/vrt-ai-review.yml
@@ -155,10 +155,10 @@ jobs:
             --json number,title,body,author,baseRefName,headRefName,state,isDraft,additions,deletions,changedFiles,labels,url \
             > vrt-ai-context/pr.json
 
-          # 直前に取得済みの pr.json から読み、API の再取得を避ける
-          PR_STATE=$(jq -r '.state' vrt-ai-context/pr.json)
-          IS_DRAFT=$(jq -r '.isDraft' vrt-ai-context/pr.json)
-          PR_AUTHOR=$(jq -r '.author.login' vrt-ai-context/pr.json)
+          # 直前に取得済みの pr.json から読み、API の再取得を避ける（1回の jq で3フィールドを取得）
+          IFS=$'\t' read -r PR_STATE IS_DRAFT PR_AUTHOR < <(
+            jq -r '[.state, (.isDraft | tostring), .author.login] | @tsv' vrt-ai-context/pr.json
+          )
 
           if ! gh pr diff "$PR_NUMBER" > vrt-ai-context/pr.diff; then
             echo "Failed to collect PR diff." > vrt-ai-context/pr.diff
@@ -209,17 +209,9 @@ jobs:
             HAS_COMMENT_CHANGES=true
           fi
 
-          if [ "$PR_STATE" = "OPEN" ]; then
-            echo "pr_open=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "pr_open=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [ "$IS_DRAFT" = "true" ]; then
-            echo "is_draft=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_draft=false" >> "$GITHUB_OUTPUT"
-          fi
+          # IS_DRAFT は jq の tostring で既に true/false 文字列になっている
+          [ "$PR_STATE" = "OPEN" ] && echo "pr_open=true" >> "$GITHUB_OUTPUT" || echo "pr_open=false" >> "$GITHUB_OUTPUT"
+          echo "is_draft=${IS_DRAFT}" >> "$GITHUB_OUTPUT"
 
           # 自動マージ判定用に dependabot PR かどうかを出力する
           case "$PR_AUTHOR" in
@@ -365,11 +357,13 @@ jobs:
           # 視覚差分なしなら無条件で success（コメント探索を省略）
           conclusion-override: ${{ steps.context.outputs.has_changes == 'false' && 'success' || '' }}
 
-  # VRT が失敗した場合に failure Check Run を publish する。
+  # VRT が success 以外で終わった場合に failure Check Run を publish する。
   # review ジョブは conclusion == 'success' のときのみ起動するため、
-  # 失敗時は vrt-ai-review Check Run が作成されず auto-merge がハングする。
-  # このジョブが failure Check Run を明示的に publish することで、
-  # dependabot-auto-merge.yml が正常にスキップ判定できる。
+  # 失敗・タイムアウト・キャンセルのいずれの場合も vrt-ai-review Check Run が
+  # 作成されず auto-merge がハングする。
+  # conclusion != 'success'（cancelled を含む）を対象とするのは意図的。
+  # キャンセルは一時的な状態だが、次回 VRT 成功時に Check Run が上書きされるまで
+  # auto-merge をブロックするのが安全側の設計。
   publish-failure-check:
     if: |
       github.event.workflow_run.event == 'pull_request' &&

--- a/.github/workflows/vrt-ai-review.yml
+++ b/.github/workflows/vrt-ai-review.yml
@@ -1,0 +1,418 @@
+name: VRT AI Review
+
+# VRT 実行完了を契機に差分を AI 評価し、結果を Check Run として publish する。
+# 呼び出し元は workflow_run トリガーを持ち、VRT ワークフロー名のみが
+# リポジトリ固有の設定となる。
+#
+# 動作フロー:
+#   - VRT success → 差分を取得して Claude が評価 → vrt-ai-review Check Run を publish
+#   - VRT failure → dependabot PR の場合のみ failure Check Run を publish
+#                   （これがないと dependabot-auto-merge が永遠に待ち続ける）
+#
+# コメントマーカー <!-- vrt-ai-review --> は全リポジトリで共通。
+# dependabot-auto-merge.yml が参照する Check Run 名も vrt-ai-review で統一。
+
+on:
+  workflow_call:
+    inputs:
+      runs-on:
+        description: ジョブを実行するマシンタイプ
+        required: false
+        type: string
+        default: ubuntu-latest
+      model:
+        description: 使用する Claude モデル
+        required: false
+        type: string
+        default: global.anthropic.claude-opus-4-7
+      check-name:
+        description: publish する Check Run 名（dependabot-auto-merge.yml が参照する）
+        required: false
+        type: string
+        default: vrt-ai-review
+      region:
+        description: AWS リージョン
+        required: false
+        type: string
+        default: ap-northeast-1
+    secrets:
+      AWS_ROLE_TO_ASSUME:
+        required: true
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+  checks: write
+
+jobs:
+  review:
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 30
+    concurrency:
+      group: vrt-ai-review-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_sha }}
+      cancel-in-progress: true
+    env:
+      AWS_REGION: ${{ inputs.region }}
+      VRT_RUN_ID: ${{ github.event.workflow_run.id }}
+      VRT_RUN_URL: ${{ github.event.workflow_run.html_url }}
+      VRT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Resolve PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="$EVENT_PR_NUMBER"
+          if [ -z "$PR_NUMBER" ]; then
+            PR_NUMBER=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/commits/${VRT_HEAD_SHA}/pulls" \
+              --jq 'map(select(.state == "open"))[0].number // .[0].number // empty')
+          fi
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR head
+        if: steps.pr.outputs.found == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 1
+
+      - name: Download VRT diff images from reg_actions branch
+        if: steps.pr.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p vrt-reg/0_diff
+
+          # VRT_RUN_ID にマッチするディレクトリを reg_actions ブランチから検索する
+          # （RUN_DATE で構築すると UTC 0時跨ぎで日付がずれるため run ID で検索）
+          PREFIX=$(gh api "repos/${GITHUB_REPOSITORY}/contents?ref=reg_actions" \
+            --jq ".[] | select(.type == \"dir\" and (.name | endswith(\"_${VRT_RUN_ID}_reg\"))) | .path" \
+            2>/dev/null | head -n 1)
+
+          if [ -z "$PREFIX" ]; then
+            echo "No reg directory found for VRT run ${VRT_RUN_ID} in reg_actions branch"
+            exit 0
+          fi
+
+          echo "Looking for diff images at: ${PREFIX}/diff (branch: reg_actions)"
+
+          # diff ディレクトリからファイルのみのパスを取得（サブディレクトリは除外）
+          FILES=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${PREFIX}/diff?ref=reg_actions" \
+            --jq '.[] | select(.type == "file") | .path' 2>/dev/null || echo "")
+
+          if [ -z "$FILES" ]; then
+            echo "No diff files found in reg_actions branch at ${PREFIX}/diff"
+            exit 0
+          fi
+
+          echo "$FILES" | while read -r path; do
+            filename=$(basename "$path")
+            echo "Downloading: $filename"
+            tmp=$(mktemp)
+            if gh api "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=reg_actions" \
+              --header "Accept: application/vnd.github.raw" > "$tmp"; then
+              mv "$tmp" "vrt-reg/0_diff/${filename}"
+            else
+              rm -f "$tmp"
+              echo "Failed to download: $filename" >&2
+            fi
+          done
+        continue-on-error: true
+
+      - name: Collect VRT review context
+        if: steps.pr.outputs.found == 'true'
+        id: context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p vrt-ai-context
+
+          gh pr view "$PR_NUMBER" \
+            --json number,title,body,author,baseRefName,headRefName,state,isDraft,additions,deletions,changedFiles,labels,url \
+            > vrt-ai-context/pr.json
+
+          # 直前に取得済みの pr.json から読み、API の再取得を避ける
+          PR_STATE=$(jq -r '.state' vrt-ai-context/pr.json)
+          IS_DRAFT=$(jq -r '.isDraft' vrt-ai-context/pr.json)
+          PR_AUTHOR=$(jq -r '.author.login' vrt-ai-context/pr.json)
+
+          if ! gh pr diff "$PR_NUMBER" > vrt-ai-context/pr.diff; then
+            echo "Failed to collect PR diff." > vrt-ai-context/pr.diff
+          fi
+
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq '.[] | select(.body != null and ((.body | contains("## ArtifactName: [`reg`]")) or (.body | contains("## ArtifactName: `reg`")))) | {id, user: .user.login, created_at, updated_at, body}' \
+            > vrt-ai-context/vrt-comments.jsonl
+
+          {
+            echo "# VRT artifact files"
+            echo
+            if [ -d vrt-reg/0_diff ]; then
+              echo "## 0_diff"
+              find vrt-reg/0_diff -type f | sort
+              echo
+            else
+              echo "VRT diff images were not downloaded."
+            fi
+          } > vrt-ai-context/vrt-artifact-files.md
+
+          {
+            echo "# VRT AI Review Context"
+            echo
+            echo "- PR: #${PR_NUMBER}"
+            echo "- VRT run: ${VRT_RUN_URL}"
+            echo "- VRT head SHA: ${VRT_HEAD_SHA}"
+            echo "- PR state: ${PR_STATE}"
+            echo "- Draft: ${IS_DRAFT}"
+            echo
+            echo "Read these files before commenting:"
+            echo "- vrt-ai-context/pr.json"
+            echo "- vrt-ai-context/pr.diff"
+            echo "- vrt-ai-context/vrt-comments.jsonl"
+            echo "- vrt-ai-context/vrt-artifact-files.md"
+            echo "- vrt-reg/0_diff/ (diff images from reg_actions branch, when available)"
+          } > vrt-ai-context/README.md
+
+          HAS_ARTIFACT_CHANGES=false
+          if find vrt-reg/0_diff -type f \( -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' -o -name '*.webp' -o -name '*.gif' -o -name '*.bmp' \) -print -quit 2>/dev/null | grep -q .; then
+            HAS_ARTIFACT_CHANGES=true
+          fi
+
+          HAS_COMMENT_CHANGES=false
+          if [ -s vrt-ai-context/vrt-comments.jsonl ] &&
+            ! grep -q "All visual differences have been resolved" vrt-ai-context/vrt-comments.jsonl; then
+            HAS_COMMENT_CHANGES=true
+          fi
+
+          if [ "$PR_STATE" = "OPEN" ]; then
+            echo "pr_open=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_open=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "is_draft=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_draft=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # 自動マージ判定用に dependabot PR かどうかを出力する
+          case "$PR_AUTHOR" in
+            *dependabot*) echo "is_dependabot=true" >> "$GITHUB_OUTPUT" ;;
+            *) echo "is_dependabot=false" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+          if [ "$HAS_ARTIFACT_CHANGES" = "true" ] || [ "$HAS_COMMENT_CHANGES" = "true" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Mark VRT AI review as resolved
+        if: |
+          steps.context.outputs.pr_open == 'true' &&
+          steps.context.outputs.is_draft == 'false' &&
+          steps.context.outputs.has_changes == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+
+          COMMENT_ID=$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body // "" | contains("<!-- vrt-ai-review -->"))) | .id' \
+            | tail -n 1)
+
+          if [ -z "$COMMENT_ID" ]; then
+            exit 0
+          fi
+
+          BODY=$(printf '%s\n' \
+            '<!-- vrt-ai-review -->' \
+            '<!-- vrt-ai-verdict:ok -->' \
+            '# VRT AI 評価' \
+            '' \
+            '最新の VRT ではレビュー対象の視覚差分はありません。' \
+            '' \
+            "- PR: #${PR_NUMBER}" \
+            "- VRT run: ${VRT_RUN_URL}")
+
+          gh api \
+            -X PATCH \
+            "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+            -f body="$BODY"
+
+      - name: Configure AWS Credentials
+        if: |
+          steps.context.outputs.pr_open == 'true' &&
+          steps.context.outputs.is_draft == 'false' &&
+          steps.context.outputs.has_changes == 'true'
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Claude VRT AI Review
+        if: |
+          steps.context.outputs.pr_open == 'true' &&
+          steps.context.outputs.is_draft == 'false' &&
+          steps.context.outputs.has_changes == 'true'
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+        with:
+          use_bedrock: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_bots: "*"
+          classify_inline_comments: false
+          prompt: |
+            **Language: 日本語で回答**
+
+            PR #${{ steps.pr.outputs.number }} の VRT 差分を評価してください。
+            VRT 実行完了を契機にした自動評価です。承認やマージは行わず、PR コメントのみを更新または投稿してください。
+
+            ## 入力
+            - `vrt-ai-context/README.md`
+            - `vrt-ai-context/pr.json`
+            - `vrt-ai-context/pr.diff`
+            - `vrt-ai-context/vrt-comments.jsonl`
+            - `vrt-ai-context/vrt-artifact-files.md`
+            - `vrt-reg/0_diff/` 配下の差分画像（reg_actions ブランチから取得）
+
+            ## 評価手順
+            1. PR の本文とコード diff から意図された変更を把握する
+            2. reg-actions のコメントと artifact から視覚差分の対象・件数・画像を確認する
+            3. VRT 差分が PR の変更内容と整合しているか、不自然な崩れや意図しない副作用がないか評価する
+            4. 画像を直接確認できない場合は、その制約を明記し、ファイル名・report・PR diff から判断できる範囲で評価する
+
+            ## コメント形式
+            コメント本文の先頭には必ず `<!-- vrt-ai-review -->` を含めてください。
+            続けて、判定に応じた検証マーカーを**いずれか1つ**必ず含めてください（自動マージの判定に使用します）。
+
+            - 問題なしの場合: `<!-- vrt-ai-verdict:ok -->`
+            - 要確認の場合: `<!-- vrt-ai-verdict:needs-review -->`
+            - 判断不可の場合: `<!-- vrt-ai-verdict:undetermined -->`
+
+            既存の `<!-- vrt-ai-review -->` コメントがあれば `gh api -X PATCH` で更新し、なければ `gh pr comment ${{ steps.pr.outputs.number }} -b` で新規投稿してください。
+
+            ```
+            <!-- vrt-ai-review -->
+            <!-- vrt-ai-verdict:ok / vrt-ai-verdict:needs-review / vrt-ai-verdict:undetermined のいずれか1つ -->
+            # VRT AI 評価
+
+            ## 判定
+            <!-- 問題なし / 要確認 / 判断不可 -->
+
+            ## 視覚差分
+            <!-- 変更・新規・削除された画面や story の要約 -->
+
+            ## PR との差分整合性
+            <!-- PR の変更意図と VRT 差分が一致しているか -->
+
+            ## レビュアーへの確認事項
+            <!-- 人間が見るべき点。なければ「なし」 -->
+            ```
+
+            コメントは簡潔にし、根拠になるファイル名や story 名があれば含めてください。
+          claude_args: |
+            --model ${{ inputs.model }}
+            --allowedTools "Read,Glob,Grep,Bash(gh api:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --max-turns 20
+
+      # VRT AI レビューの判定を Check Run として publish する。
+      # 視覚差分が無ければ無条件で success、差分がある場合はコメントの
+      # 検証マーカー（vrt-ai-verdict:ok）で判定する。
+      # dependabot PR のみ作成し、人間の PR にはチェックを足さない。
+      - name: Publish VRT AI review check run
+        if: |
+          steps.pr.outputs.found == 'true' &&
+          steps.context.outputs.is_dependabot == 'true' &&
+          steps.context.outputs.pr_open == 'true' &&
+          steps.context.outputs.is_draft == 'false'
+        uses: ./.github/actions/publish-check-run
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          check-name: ${{ inputs.check-name }}
+          title: VRT AI review
+          head-sha: ${{ github.event.workflow_run.head_sha }}
+          pr-number: ${{ steps.pr.outputs.number }}
+          marker: '<!-- vrt-ai-review -->'
+          ok-marker: '<!-- vrt-ai-verdict:ok -->'
+          # 視覚差分なしなら無条件で success（コメント探索を省略）
+          conclusion-override: ${{ steps.context.outputs.has_changes == 'false' && 'success' || '' }}
+
+  # VRT が失敗した場合に failure Check Run を publish する。
+  # review ジョブは conclusion == 'success' のときのみ起動するため、
+  # 失敗時は vrt-ai-review Check Run が作成されず auto-merge がハングする。
+  # このジョブが failure Check Run を明示的に publish することで、
+  # dependabot-auto-merge.yml が正常にスキップ判定できる。
+  publish-failure-check:
+    if: |
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VRT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Resolve PR and check if dependabot
+        id: pr
+        env:
+          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="$EVENT_PR_NUMBER"
+          if [ -z "$PR_NUMBER" ]; then
+            PR_NUMBER=$(gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/commits/${VRT_HEAD_SHA}/pulls" \
+              --jq 'map(select(.state == "open"))[0].number // .[0].number // empty')
+          fi
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "is_dependabot=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          IS_DEPENDABOT=$(gh pr view "$PR_NUMBER" \
+            --json author --jq '.author.login | test("dependabot")')
+          echo "is_dependabot=${IS_DEPENDABOT}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish failure Check Run
+        if: steps.pr.outputs.is_dependabot == 'true'
+        run: |
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/check-runs" \
+            -f name="${{ inputs.check-name }}" \
+            -f head_sha="${VRT_HEAD_SHA}" \
+            -f status='completed' \
+            -f conclusion='failure' \
+            -f 'output[title]=VRT AI review' \
+            -f 'output[summary]=VRT が失敗したため VRT AI レビューを実施できませんでした。' \
+            > /dev/null


### PR DESCRIPTION
## 概要

VRT 実行完了を契機に差分を AI 評価し、結果を Check Run として publish する共有ワークフローを追加します。

各リポジトリは `workflow_run` トリガー（VRT ワークフロー名のみリポジトリ固有）を持ち、このワークフローを呼び出すだけで VRT AI レビューを導入できます。

```mermaid
flowchart TD
    A[VRT ワークフロー完了] --> B{conclusion}
    B -->|success| C[vrt-ai-review.yml / review ジョブ]
    B -->|failure / cancelled| D[vrt-ai-review.yml / publish-failure-check ジョブ]

    C --> E[PR 解決]
    E --> F[VRT diff 画像ダウンロード]
    F --> G[レビューコンテキスト収集]
    G --> H{差分あり?}
    H -->|なし| I[既存コメントを解消済みに更新]
    H -->|あり| J[Claude VRT AI レビュー]
    I --> K[vrt-ai-review Check Run を publish]
    J --> K

    D --> L[PR が dependabot PR か確認]
    L -->|Yes| M[vrt-ai-review failure Check Run を publish]
    L -->|No| N[スキップ]
```

**設計方針:**
- コメントマーカーを `<\!-- vrt-ai-review -->` に統一（リポジトリ固有サフィックスを廃止）
- VRT 失敗・キャンセル時も `publish-failure-check` ジョブが failure Check Run を publish
  （これがないと `dependabot-auto-merge` が永遠に待ち続けてハングする）
- `publish-check-run` composite action を内包（API 呼び出し1段階化・`[[ ]]` パターンマッチ適用済み）

## 追加ファイル

- `.github/workflows/vrt-ai-review.yml`（reusable workflow 本体）
- `.github/actions/publish-check-run/action.yml`（Check Run publish composite action）

## 呼び出し側の実装例

```yaml
on:
  workflow_run:
    workflows: [VRT (my-app)]   # VRT ワークフロー名のみリポジトリ固有
    types: [completed]
permissions:
  actions: read
  contents: read
  pull-requests: write
  issues: write
  id-token: write
  checks: write
jobs:
  vrt-ai-review:
    uses: mixi-m/github-actions/.github/workflows/vrt-ai-review.yml@master
    secrets:
      AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
```