### PR TITLE
fix(ci): vrt-ai-review のローカルアクション参照を完全パス指定に修正

### DIFF
--- a/.github/workflows/vrt-ai-review.yml
+++ b/.github/workflows/vrt-ai-review.yml
@@ -345,7 +345,7 @@ jobs:
           steps.context.outputs.is_dependabot == 'true' &&
           steps.context.outputs.pr_open == 'true' &&
           steps.context.outputs.is_draft == 'false'
-        uses: ./.github/actions/publish-check-run
+        uses: mixi-m/github-actions/.github/actions/publish-check-run@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           check-name: ${{ inputs.check-name }}


### PR DESCRIPTION
## 概要

`vrt-ai-review.yml` の `Publish VRT AI review check run` ステップが、`workflow_run` トリガー + 別リポジトリ checkout の環境でローカルアクション参照（`./`）を使用していたため、dependabot PR での実行時に失敗していた問題を修正します。

### 根本原因

GitHub Actions の仕様上、`./` 形式のローカルアクション参照は `$GITHUB_WORKSPACE`（チェックアウト済み作業ディレクトリ）を基準に解決されます。

このワークフローは `workflow_call` で呼び出され、呼び出し元リポジトリの PR head をワークスペースにチェックアウトします。その結果、アクションの解決先が呼び出し元リポジトリの `.github/actions/publish-check-run` になりますが、呼び出し元リポジトリにはこのアクションが存在しないため `action.yml` が見つからず失敗していました。

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/runner/work/_workspace/.github/actions/publish-check-run'.
Did you forget to run actions/checkout before running your local action?
```

### 修正内容

ローカル参照を完全パス指定（`owner/repo/path@ref`）に変更しました。完全パス指定では別ディレクトリに展開されるため、ワークスペースが上書きされても影響を受けません。

```yaml
# 修正前
uses: ./.github/actions/publish-check-run

# 修正後
uses: mixi-m/github-actions/.github/actions/publish-check-run@master
```

### 影響範囲

- このステップは `is_dependabot == 'true'` の分岐でのみ実行されるため、dependabot PR でのみ顕在化していた
- 本不具合により `dependabot-auto-merge` が `vrt-ai-review` Check Run を待ち続けてブロックされる状態になっていた

## 影響範囲

`vrt-ai-review.yml` を再利用しているリポジトリの dependabot PR における `Publish VRT AI review check run` ステップ

## 確認事項

- [x] コーディングガイドラインに従っている
- [x] この差分がセキュリティに悪影響を与えていない

## 動作確認

1. マージ後、このワークフローを利用しているリポジトリの dependabot PR で VRT が完了する（または手動で `workflow_run` を再トリガーする）
2. `vrt-ai-review / review` ジョブの `Publish VRT AI review check run` ステップがエラーなく完了することを確認
3. `vrt-ai-review` Check Run が head SHA に publish され、`dependabot-auto-merge` が待ち状態から進むことを確認