### PR TITLE
fix(ci): request explicit token permissions for auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -96,6 +96,15 @@ jobs:
         with:
           client-id: ${{ inputs.app-client-id }}
           private-key: ${{ secrets.app-private-key }}
+          # 必要権限を明示する（不足していればここで権限名付きで即失敗する）。
+          # - contents:write        … マージ / merge queue 投入
+          # - pull-requests:write   … PR 解決・承認・auto-merge 有効化
+          # - checks:read           … コードレビュー / VRT の Check Run 参照
+          # - actions:read          … VRT ワークフローの起動有無の確認
+          permission-contents: write
+          permission-pull-requests: write
+          permission-checks: read
+          permission-actions: read
 
       - name: Resolve PR and evaluate gates
         env:


### PR DESCRIPTION
## 概要

`dependabot-auto-merge.yml` の App トークン生成で、必要な権限を明示的に要求する。

```yaml
permission-contents: write       # マージ / merge queue 投入
permission-pull-requests: write  # PR 解決・承認・auto-merge 有効化
permission-checks: read          # Check Run（コードレビュー / VRT）参照
permission-actions: read         # ワークフロー起動有無の確認
```

## 背景

App トークンが必要権限を欠く場合、ゲート途中の `gh api` 呼び出しで不透明な
`Resource not accessible by integration (HTTP 403)` が出て、どの権限が不足しているか
特定しづらい。権限を明示要求すれば、不足時にトークン生成ステップで権限名付きで
即座に失敗するため切り分けが容易になる。最小権限の明示にもなる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)