### PR TITLE
update: Claude モデルを claude-opus-4-8 に更新、Elixir の transitive dependency を調査対象に追加

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-7'
+        default: 'global.anthropic.claude-opus-4-8'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/claude-pr-auto-review.yml
+++ b/.github/workflows/claude-pr-auto-review.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-7'
+        default: 'global.anthropic.claude-opus-4-8'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/review-dependabot.yml
+++ b/.github/workflows/review-dependabot.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-7'
+        default: 'global.anthropic.claude-opus-4-8'
       region:
         description: 'AWS region to use'
         required: false
@@ -94,8 +94,9 @@ jobs:
 
             1. `gh pr view ${{ github.event.pull_request.number }}` で PR 本文・リリースノートを確認する
             2. `gh pr diff ${{ github.event.pull_request.number }}` で変更内容を確認する
-            3. 更新された依存関係をこのリポジトリで実際に使用している箇所を `Grep` や `Read` で確認する
-            4. 破壊的変更と実使用箇所への影響を評価する
+            3. **Elixir プロジェクト（mix.lock が変更されている場合）**: mix.lock の差分から更新された全パッケージを特定する。Dependabot が直接ターゲットにしたパッケージだけでなく、それの依存として連鎖更新されたパッケージ（例: plug 等）も含めて、各パッケージのリリースノート・破壊的変更を個別に調査する
+            4. 更新された依存関係をこのリポジトリで実際に使用している箇所を `Grep` や `Read` で確認する
+            5. 破壊的変更と実使用箇所への影響を評価する
 
             ## レビューコメント
 
@@ -105,7 +106,7 @@ jobs:
             # Dependabot PR レビュー
 
             ## 対象
-            <!-- パッケージ名@旧バージョン → 新バージョン -->
+            <!-- パッケージ名@旧バージョン → 新バージョン（依存として連鎖更新されたパッケージがある場合はすべて列挙） -->
 
             ## サマリー
             <!-- 変更内容の概要 -->

--- a/.github/workflows/vrt-ai-review.yml
+++ b/.github/workflows/vrt-ai-review.yml
@@ -24,7 +24,7 @@ on:
         description: 使用する Claude モデル
         required: false
         type: string
-        default: global.anthropic.claude-opus-4-7
+        default: global.anthropic.claude-opus-4-8
       check-name:
         description: publish する Check Run 名（dependabot-auto-merge.yml が参照する）
         required: false


### PR DESCRIPTION
## Summary

- 全 reusable workflow のデフォルトモデルを `claude-opus-4-7` → `claude-opus-4-8` に変更
  - `claude-code.yml`
  - `claude-pr-auto-review.yml`
  - `review-dependabot.yml`
  - `vrt-ai-review.yml`
- `review-dependabot.yml`: Elixir プロジェクト（`mix.lock` が変更されている場合）において、Dependabot が直接ターゲットにしたパッケージだけでなく、依存として連鎖更新されたパッケージも個別に調査するよう分析手順を追加

## Test plan

- [ ] 各ワークフローの `model` input に値を渡さない場合、`claude-opus-4-8` が使用されること
- [ ] Elixir プロジェクトの Dependabot PR で `mix.lock` に複数パッケージの変更がある場合、連鎖更新分も調査されること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)