### PR TITLE
build: update default Claude model to Sonnet 5

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-8'
+        default: 'global.anthropic.claude-sonnet-5'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/claude-pr-auto-review.yml
+++ b/.github/workflows/claude-pr-auto-review.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-8'
+        default: 'global.anthropic.claude-sonnet-5'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/review-dependabot.yml
+++ b/.github/workflows/review-dependabot.yml
@@ -12,7 +12,7 @@ on:
         description: 'The Claude model to use'
         required: false
         type: string
-        default: 'global.anthropic.claude-opus-4-8'
+        default: 'global.anthropic.claude-sonnet-5'
       region:
         description: 'AWS region to use'
         required: false

--- a/.github/workflows/vrt-ai-review.yml
+++ b/.github/workflows/vrt-ai-review.yml
@@ -24,7 +24,7 @@ on:
         description: 使用する Claude モデル
         required: false
         type: string
-        default: global.anthropic.claude-opus-4-8
+        default: global.anthropic.claude-sonnet-5
       check-name:
         description: publish する Check Run 名（dependabot-auto-merge.yml が参照する）
         required: false


### PR DESCRIPTION
## Summary
- Reusable workflow で使用している Claude モデルのデフォルト値を `global.anthropic.claude-opus-4-8` から `global.anthropic.claude-sonnet-5` に変更

## 対象ファイル
- `.github/workflows/claude-code.yml`
- `.github/workflows/claude-pr-auto-review.yml`
- `.github/workflows/review-dependabot.yml`
- `.github/workflows/vrt-ai-review.yml`

## Test plan
- [ ] 各ワークフローが Sonnet 5 で正常に実行されることを確認する