### PR TITLE
chore: update review skill reference for renamed engineering skill

### DIFF
--- a/.github/workflows/claude-pr-auto-review.yml
+++ b/.github/workflows/claude-pr-auto-review.yml
@@ -67,7 +67,7 @@ jobs:
 
             # Automatic Code Review for PR #${{ github.event.pull_request.number }}
 
-            このリポジトリに `engineering:code-review` スキルが定義されていれば、それを参照してください。
+            このリポジトリに `engineering:review-criteria` スキルが定義されていれば、それを参照してください。
             定義されていない場合は、以下の観点でレビューを行ってください。
 
             ## レビュー観点


### PR DESCRIPTION
## Summary
- ワークフローが参照しているレビュー用スキル名が変更されたため、プロンプト内の参照名を更新
- 呼び出し先のエージェントで組み込みのレビューコマンドと名前が衝突していたことが変更理由

## Test plan
- [ ] このワークフローを実行し、レビュー用スキルが引き続き正しく参照・適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)