### PR TITLE
fix(review-dependabot): max-turns 上限を撤廃しレビュー範囲を最適化

### DIFF
--- a/.github/workflows/review-dependabot.yml
+++ b/.github/workflows/review-dependabot.yml
@@ -94,9 +94,9 @@ jobs:
 
             1. `gh pr view ${{ github.event.pull_request.number }}` で PR 本文・リリースノートを確認する
             2. `gh pr diff ${{ github.event.pull_request.number }}` で変更内容を確認する
-            3. **Elixir プロジェクト（mix.lock が変更されている場合）**: mix.lock の差分から更新された全パッケージを特定する。Dependabot が直接ターゲットにしたパッケージだけでなく、それの依存として連鎖更新されたパッケージ（例: plug 等）も含めて、各パッケージのリリースノート・破壊的変更を個別に調査する
-            4. 更新された依存関係をこのリポジトリで実際に使用している箇所を `Grep` や `Read` で確認する
-            5. 破壊的変更と実使用箇所への影響を評価する
+            3. **Elixir プロジェクト（mix.lock が変更されている場合）**: mix.lock の差分から更新された全パッケージ（Dependabot が直接ターゲットにしたものだけでなく、依存として連鎖更新されたパッケージも含む）を特定する
+            4. 特定した各パッケージをこのリポジトリで実際に使用している箇所を `Grep` や `Read` で確認する
+            5. 実使用箇所があるパッケージについてのみ、`WebFetch` でリリースノートを確認し、破壊的変更の有無と実使用箇所への影響を評価する（実使用箇所がないパッケージは「影響なし」として個別調査は省略してよい）
 
             ## レビューコメント
 
@@ -128,8 +128,7 @@ jobs:
             このPRは承認しないでください。コメントのみ残してください。
           claude_args: |
             --model ${{ inputs.model }}
-            --allowedTools "Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-            --max-turns 20
+            --allowedTools "Read,Glob,Grep,WebFetch,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
       # publish-check-run が true のときのみ、レビュー判定を Check Run として
       # publish する。判定はコメントに埋め込まれた検証マーカーから導出する。


### PR DESCRIPTION
## Summary
- Dependabot PR レビューが `Reached maximum number of turns (20)` で失敗するケースが増えていたため対応
- `--max-turns 20` の指定を削除（他ワークフロー（claude-code.yml / claude-pr-auto-review.yml）と同様、上限は `timeout-minutes` に委ねる）
- 分析手順を「実使用箇所の確認 → 実使用箇所があるパッケージだけリリースノート調査」の順に変更し、無関係な連鎖更新パッケージへの個別調査を省略できるようにした
- `allowedTools` に `WebFetch` を追加し、リリースノート確認を直接行えるようにした（Grep/Read での試行錯誤を減らす）

## Test plan
- [ ] mix.lock で複数パッケージが連鎖更新される Dependabot PR で本ワークフローを実行し、ターン数エラーが発生しないことを確認
- [ ] レビューコメントの内容が期待通りのフォーマットで出力されることを確認
- [ ] `emit-verdict` / `publish-check-run` を有効にした呼び出し元でも従来通り判定マーカーが出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)