### PR TITLE
fix: dependabotレビューのコメント投稿失敗とVRT過剰慎重判定を修正

### DIFF
--- a/.github/workflows/review-dependabot.yml
+++ b/.github/workflows/review-dependabot.yml
@@ -101,7 +101,9 @@ jobs:
             ## レビューコメント
 
             コメント内で順序や件数などを番号で表す際は `#` を付けないこと（`#1` や `#123` が GitHub 上で無関係な Issue/PR へのリンクとして解釈されるため）。
-            以下のテンプレートで `gh pr comment ${{ github.event.pull_request.number }} -b` を使ってコメントしてください:
+            以下のテンプレートの内容を Write ツールでファイル（例: `/tmp/dependabot-review-comment.md`）に書き出してから、
+            `gh pr comment ${{ github.event.pull_request.number }} --body-file <そのファイルパス>` で投稿してください。
+            heredoc やシェルのパイプ経由での投稿（`gh pr comment ... -b "$(cat <<EOF ... )"` 等）は使わないこと。
 
             ```
             # Dependabot PR レビュー
@@ -128,7 +130,7 @@ jobs:
             このPRは承認しないでください。コメントのみ残してください。
           claude_args: |
             --model ${{ inputs.model }}
-            --allowedTools "Read,Glob,Grep,WebFetch,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Read,Write,Glob,Grep,WebFetch,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
       # publish-check-run が true のときのみ、レビュー判定を Check Run として
       # publish する。判定はコメントに埋め込まれた検証マーカーから導出する。

--- a/.github/workflows/vrt-ai-review.yml
+++ b/.github/workflows/vrt-ai-review.yml
@@ -96,13 +96,13 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 1
 
-      - name: Download VRT diff images from reg_actions branch
+      - name: Download VRT diff/actual/expected images from reg_actions branch
         if: steps.pr.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          mkdir -p vrt-reg/0_diff
+          mkdir -p vrt-reg/0_diff vrt-reg/1_actual vrt-reg/2_expected
 
           # VRT_RUN_ID にマッチするディレクトリを reg_actions ブランチから検索する
           # （RUN_DATE で構築すると UTC 0時跨ぎで日付がずれるため run ID で検索）
@@ -115,29 +115,36 @@ jobs:
             exit 0
           fi
 
-          echo "Looking for diff images at: ${PREFIX}/diff (branch: reg_actions)"
-
-          # diff ディレクトリからファイルのみのパスを取得（サブディレクトリは除外）
-          FILES=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${PREFIX}/diff?ref=reg_actions" \
-            --jq '.[] | select(.type == "file") | .path' 2>/dev/null || echo "")
-
-          if [ -z "$FILES" ]; then
-            echo "No diff files found in reg_actions branch at ${PREFIX}/diff"
-            exit 0
-          fi
-
-          echo "$FILES" | while read -r path; do
-            filename=$(basename "$path")
-            echo "Downloading: $filename"
-            tmp=$(mktemp)
-            if gh api "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=reg_actions" \
-              --header "Accept: application/vnd.github.raw" > "$tmp"; then
-              mv "$tmp" "vrt-reg/0_diff/${filename}"
-            else
-              rm -f "$tmp"
-              echo "Failed to download: $filename" >&2
+          # reg-suit のレポート構造は {PREFIX}/diff, {PREFIX}/actual, {PREFIX}/expected。
+          # diff にあるファイルと同じファイル名（拡張子は異なりうる）の actual/expected を
+          # 突き合わせてダウンロードし、AI が実際に見た目を比較できるようにする。
+          download_dir() {
+            local subdir="$1"
+            local outdir="$2"
+            local files
+            files=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${PREFIX}/${subdir}?ref=reg_actions" \
+              --jq '.[] | select(.type == "file") | .path' 2>/dev/null || echo "")
+            if [ -z "$files" ]; then
+              echo "No files found in reg_actions branch at ${PREFIX}/${subdir}"
+              return 0
             fi
-          done
+            echo "$files" | while read -r path; do
+              filename=$(basename "$path")
+              echo "Downloading (${subdir}): $filename"
+              tmp=$(mktemp)
+              if gh api "repos/${GITHUB_REPOSITORY}/contents/${path}?ref=reg_actions" \
+                --header "Accept: application/vnd.github.raw" > "$tmp"; then
+                mv "$tmp" "${outdir}/${filename}"
+              else
+                rm -f "$tmp"
+                echo "Failed to download: $filename" >&2
+              fi
+            done
+          }
+
+          download_dir diff vrt-reg/0_diff
+          download_dir actual vrt-reg/1_actual
+          download_dir expected vrt-reg/2_expected
         continue-on-error: true
 
       - name: Collect VRT review context
@@ -172,11 +179,14 @@ jobs:
           {
             echo "# VRT artifact files"
             echo
-            if [ -d vrt-reg/0_diff ]; then
-              echo "## 0_diff"
-              find vrt-reg/0_diff -type f | sort
-              echo
-            else
+            for dir in vrt-reg/0_diff vrt-reg/1_actual vrt-reg/2_expected; do
+              if [ -d "$dir" ] && [ -n "$(ls -A "$dir" 2>/dev/null)" ]; then
+                echo "## ${dir}"
+                find "$dir" -type f | sort
+                echo
+              fi
+            done
+            if [ -z "$(ls -A vrt-reg/0_diff 2>/dev/null)" ]; then
               echo "VRT diff images were not downloaded."
             fi
           } > vrt-ai-context/vrt-artifact-files.md
@@ -195,7 +205,9 @@ jobs:
             echo "- vrt-ai-context/pr.diff"
             echo "- vrt-ai-context/vrt-comments.jsonl"
             echo "- vrt-ai-context/vrt-artifact-files.md"
-            echo "- vrt-reg/0_diff/ (diff images from reg_actions branch, when available)"
+            echo "- vrt-reg/0_diff/ (diff画像。差分がハイライトされた画像。reg_actions ブランチから取得、あれば)"
+            echo "- vrt-reg/1_actual/ (actual画像。変更後のスクリーンショット。0_diff と同名ファイルが対応)"
+            echo "- vrt-reg/2_expected/ (expected画像。変更前=ベースラインのスクリーンショット。0_diff と同名ファイルが対応)"
           } > vrt-ai-context/README.md
 
           HAS_ARTIFACT_CHANGES=false
@@ -293,13 +305,16 @@ jobs:
             - `vrt-ai-context/pr.diff`
             - `vrt-ai-context/vrt-comments.jsonl`
             - `vrt-ai-context/vrt-artifact-files.md`
-            - `vrt-reg/0_diff/` 配下の差分画像（reg_actions ブランチから取得）
+            - `vrt-reg/0_diff/` 配下の差分ハイライト画像（reg_actions ブランチから取得、あれば）
+            - `vrt-reg/1_actual/` 配下の変更後スクリーンショット（0_diff と同名ファイルが対応）
+            - `vrt-reg/2_expected/` 配下の変更前(ベースライン)スクリーンショット（0_diff と同名ファイルが対応）
 
             ## 評価手順
             1. PR の本文とコード diff から意図された変更を把握する
-            2. reg-actions のコメントと artifact から視覚差分の対象・件数・画像を確認する
-            3. VRT 差分が PR の変更内容と整合しているか、不自然な崩れや意図しない副作用がないか評価する
-            4. 画像を直接確認できない場合は、その制約を明記し、ファイル名・report・PR diff から判断できる範囲で評価する
+            2. reg-actions のコメントと artifact から視覚差分の対象・件数を確認する
+            3. 差分が検出された各ファイルについて、`Read` ツールで `1_actual` と `2_expected` の同名画像を両方直接見て見比べる（`0_diff` のハイライト画像だけで判断しないこと）。実際に画像を比較した上で、レイアウト崩れ等の実質的な差分か、ローディング中の表示・アニメーションの一コマ・アンチエイリアシング等の無関係なフレーキーな差分かを判定する
+            4. VRT 差分が PR の変更内容(diffの変更範囲)と整合しているか、不自然な崩れや意図しない副作用がないか評価する
+            5. `1_actual` / `2_expected` の画像が取得できずファイル自体を直接確認できない場合に限り、その制約を明記し、ファイル名・report・PR diff から判断できる範囲で評価する（画像が揃っているのに比較せず「確認不可」と判定しないこと）
 
             ## コメント形式
             コメント本文の先頭には必ず `<!-- vrt-ai-review -->` を含めてください。


### PR DESCRIPTION
## 概要

このワークフローの利用先リポジトリでの運用調査を通じて判明した、dependabot自動マージが正しく機能しないケース2件を修正する。

## 修正1: review-dependabot.yml — コメント投稿がpermission denialで失敗する問題

Claude AI Reviewのジョブ自体は `success` で完了しているにもかかわらず、PRへのコメントが一切投稿されず、検証マーカーが見つからないため `dependabot-code-review` Check Runが`neutral`（非success）にフォールバックするケースを確認した。

ジョブのログには `"permission_denials_count": 1` が記録されており、`gh pr comment ... -b "$(cat <<EOF ...)"` のようなheredoc/パイプ経由の投稿コマンドが `allowedTools` の `Bash(gh pr comment:*)` パターンにマッチせず拒否され、そのままコメント投稿されずに終了していたと考えられる。

**修正**: `Write` ツールをallowedToolsに追加し、コメント本文をファイルに書き出してから `gh pr comment --body-file` で投稿する方式に変更した。

## 修正2: vrt-ai-review.yml — VRT差分の実画像を比較せず過剰に慎重な判定になる問題

AIレビューコメント自身が「actual/expected画像を直接比較できていないため断定できない」と明記した上で `needs-review` 判定にしているケースを確認した。ワークフローは reg_actions ブランチから `diff`（差分ハイライト）画像のみをダウンロードしており、判断に必要な `actual`（変更後）/ `expected`（変更前=ベースライン）の実画像を取得していなかった。

**修正**: `actual` / `expected` ディレクトリの画像もダウンロードし、AIに `Read` ツールで両方を直接比較させた上で判定するようプロンプトを変更した。画像が揃っているのに比較せず「確認不可」と判定することを明示的に禁止した。

## 影響範囲

このリポジトリを参照している全てのdependabot自動マージ導入済みリポジトリに影響する。プロンプト・ツール許可の変更のみで、Check Run名やワークフロー呼び出しのインターフェースは変更していない。

## テスト

ワークフロー変更のため、実際のdependabot PRでの動作確認が必要。マージ前に利用先リポジトリで数件のdependabot PRに対して実際にレビューを走らせ、コメントが正しく投稿されること・VRT判定が改善されることを確認することを推奨する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
