### PR TITLE
fix: pull_request_review 時に CodeBuild の source-version を PR HEAD に固定する

### DIFF
--- a/.github/workflows/kick-codebuild.yaml
+++ b/.github/workflows/kick-codebuild.yaml
@@ -48,3 +48,8 @@ jobs:
         with:
           project-name: ${{ inputs.codebuild_project_name }}
           buildspec-override: ${{ inputs.codebuild_buildspec }}
+          # デフォルトでは GITHUB_SHA (pull_request_review イベントでは ephemeral な merge commit) が
+          # CodeBuild の sourceVersion として渡される。base ブランチの更新で merge commit が
+          # 再計算されると古い SHA が無効になり CodeBuild 側の checkout が失敗するため、
+          # checkout の ref と同様に PR HEAD の SHA を明示的に指定する。
+          source-version-override: ${{ github.event_name == 'pull_request_review' && github.event.pull_request.head.sha || '' }}


### PR DESCRIPTION
## Summary
- `pull_request_review` イベントでは `GITHUB_SHA` が ephemeral な merge commit を指すため、base ブランチの更新でその merge commit が再計算されると、CodeBuild 側の source checkout が `fatal: reference is not a tree` で失敗することがある
- `actions/checkout` の `ref` は既に PR HEAD の SHA を明示指定する対応がされていたが、`aws-codebuild-run-build` に渡す `source-version-override` は未指定で `GITHUB_SHA` のままだったため、CodeBuild 内部の checkout だけが古い merge commit を参照し続けていた
- checkout と同じ条件式で `source-version-override` に PR HEAD の SHA を渡すよう修正

## Test plan
- [ ] `pull_request_review` イベントで `kick-codebuild.yaml` を呼び出しているワークフローの再実行が成功することを確認